### PR TITLE
Fix `AttributeError: module 'triton.language.math' has no attribute 'min'`

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -148,7 +148,7 @@ class TritonPrinter(PythonPrinter):
 
         import triton.language as tl
 
-        if "propagate_nan" in inspect.signature(tl.math.min).parameters:
+        if "propagate_nan" in inspect.signature(tl.minimum).parameters:
             # tl.PropagateNan.NONE is the default
             propagate_nan_arg = ", tl.PropagateNan.NONE"
         else:
@@ -164,7 +164,7 @@ class TritonPrinter(PythonPrinter):
         mid = len(expr.args) // 2
         a = self._print(sympy.Min(*expr.args[:mid]))
         b = self._print(sympy.Min(*expr.args[mid:]))
-        return f"tl.math.min({a}, {b}{TritonPrinter._propagate_nan_arg()})"
+        return f"tl.minimum({a}, {b}{TritonPrinter._propagate_nan_arg()})"
 
     def _print_Max(self, expr):
         nargs = len(expr.args)
@@ -174,7 +174,7 @@ class TritonPrinter(PythonPrinter):
         mid = len(expr.args) // 2
         a = self._print(sympy.Max(*expr.args[:mid]))
         b = self._print(sympy.Max(*expr.args[mid:]))
-        return f"tl.math.max({a}, {b}{TritonPrinter._propagate_nan_arg()})"
+        return f"tl.maximum({a}, {b}{TritonPrinter._propagate_nan_arg()})"
 
     def _print_Abs(self, expr):
         assert len(expr.args) == 1


### PR DESCRIPTION
The change is caused by https://github.com/openai/triton/commit/f83a5f0fd26fdf5abe3f03ac021de3ee85285b1b.